### PR TITLE
Support FIFO threshold > 1

### DIFF
--- a/examples/FIFO_Interrupt/FIFO_Interrupt.ino
+++ b/examples/FIFO_Interrupt/FIFO_Interrupt.ino
@@ -3,6 +3,12 @@
 // Instantiate an ICM42670P with SPI interface and CS on pin 8
 ICM42670P IMU(SPI,8);
 
+uint8_t irq_received = 0;
+
+void irq_handler(void)
+{
+  irq_received = 1;
+}
 
 void event_cb(inv_imu_sensor_event_t *evt)
 {
@@ -34,8 +40,8 @@ void setup() {
     Serial.println(ret);
     while(1);
   }
-  // Enable interrupt on pin 2, Fifo watermark=1
-  IMU.enableFifoInterrupt(2,event_cb);
+  // Enable interrupt on pin 2, Fifo watermark=10
+  IMU.enableFifoInterrupt(2,irq_handler,10);
   // Accel ODR = 100 Hz and Full Scale Range = 16G
   IMU.startAccel(100,16);
   // Gyro ODR = 100 Hz and Full Scale Range = 2000 dps
@@ -45,5 +51,10 @@ void setup() {
 }
 
 void loop() {
- // Do nothing
+  // Wait for interrupt to read data from fifo
+  if(irq_received)
+  {
+      irq_received = 0;
+      IMU.getDataFromFifo(event_cb);
+  }
 }

--- a/src/ICM42670P.h
+++ b/src/ICM42670P.h
@@ -36,7 +36,9 @@ extern "C" {
 }
 
 // This defines the handler called when retrieving a sample from the FIFO
-typedef void (*sensor_event_cb)(inv_imu_sensor_event_t *event);
+typedef void (*ICM42670P_sensor_event_cb)(inv_imu_sensor_event_t *event);
+// This defines the handler called when receiving an irq
+typedef void (*ICM42670P_irq_handler)(void);
 
 class ICM42670P {
   public:
@@ -45,12 +47,14 @@ class ICM42670P {
     int begin();
     int startAccel(uint16_t odr, uint16_t fsr);
     int startGyro(uint16_t odr, uint16_t fsr);
-    getDataFromRegisters(inv_imu_sensor_event_t* evt);
-    enableFifoInterrupt(uint8_t intpin, sensor_event_cb event_cb);
+    int getDataFromRegisters(inv_imu_sensor_event_t* evt);
+    int enableFifoInterrupt(uint8_t intpin, ICM42670P_irq_handler handler, uint8_t fifo_watermark);
+    int getDataFromFifo(ICM42670P_sensor_event_cb event_cb);
+
   protected:
     struct inv_imu_device icm_driver;
     ACCEL_CONFIG0_ODR_t accel_freq_to_param(uint16_t accel_freq_hz);
-    gyro_freq_to_param(uint16_t gyro_freq_hz);
+    GYRO_CONFIG0_ODR_t gyro_freq_to_param(uint16_t gyro_freq_hz);
     ACCEL_CONFIG0_FS_SEL_t accel_fsr_g_to_param(uint16_t accel_fsr_g);
     GYRO_CONFIG0_FS_SEL_t gyro_fsr_dps_to_param(uint16_t gyro_fsr_dps);
 };


### PR DESCRIPTION
Increased SPI speed to 16M
Increased driver max read/write size to 2048
Reworked API to
-	avoid reading the fifo from the irq handler
-	Configure the fifo watermark (direct register access)
-	Disable APEX to use 2.25kB FIFO
Improved SPI read procedure