### PR TITLE
Fix Incorrect SPI Mode Initialization in Sensor Driver

### DIFF
--- a/src/ICM42670P.cpp
+++ b/src/ICM42670P.cpp
@@ -320,7 +320,7 @@ static int i2c_read(inv_imu_serif* serif, uint8_t reg, uint8_t * rbuffer, uint32
 
 static int spi_write(inv_imu_serif* serif, uint8_t reg, const uint8_t * wbuffer, uint32_t wlen) {
   ICM42670P* obj = (ICM42670P*)serif->context;
-  obj->spi->beginTransaction(SPISettings(SPI_CLOCK, MSBFIRST, SPI_MODE1));
+  obj->spi->beginTransaction(SPISettings(SPI_CLOCK, MSBFIRST, SPI_MODE0));
   digitalWrite(obj->spi_cs,LOW);
   obj->spi->transfer(reg);
   for(uint8_t i = 0; i < wlen; i++) {
@@ -333,7 +333,7 @@ static int spi_write(inv_imu_serif* serif, uint8_t reg, const uint8_t * wbuffer,
 
 static int spi_read(inv_imu_serif* serif, uint8_t reg, uint8_t * rbuffer, uint32_t rlen) {
   ICM42670P* obj = (ICM42670P*)serif->context;
-  obj->spi->beginTransaction(SPISettings(SPI_CLOCK, MSBFIRST, SPI_MODE1));
+  obj->spi->beginTransaction(SPISettings(SPI_CLOCK, MSBFIRST, SPI_MODE0));
   digitalWrite(obj->spi_cs,LOW);
   obj->spi->transfer(reg | SPI_READ);
   obj->spi->transfer(rbuffer,rlen);


### PR DESCRIPTION
This commit addresses an issue where the sensor was not being driven correctly due to an error in the initialization of the SPI mode. As per the sensor datasheet (ICM-42670-P), on Page 45, under the DEVICE_CONFIG register, bit 0 is defined crucial for SPI mode selection. After reset, this register is initialized to 0x40, with the default value of bit 0 set to 0, indicating "SPI mode selection 0: Mode 0 and Mode 3".

The correction made in this commit involves setting the host's SPI mode to either Mode 0 or Mode 3, as per the default configuration of the sensor. This change ensures that the sensor is driven correctly, aligning the driver configuration with the sensor's default state post-reset. This fix is essential for the proper operation of the sensor using SPI communication.
![image](https://github.com/tdk-invn-oss/motion.arduino.ICM42670P/assets/59756183/d9434b1b-9593-4e17-975b-96447e18d1f2)
